### PR TITLE
Origin/config file readers

### DIFF
--- a/src/main/config/pod/CommonConfigData.java
+++ b/src/main/config/pod/CommonConfigData.java
@@ -1,0 +1,92 @@
+package main.config.pod;
+
+import java.util.InvalidPropertiesFormatException;
+
+public class CommonConfigData {
+    public int getNumberPreferrredNeighbors() {
+        return numberPreferrredNeighbors;
+    }
+
+    public int getUnchokeInterval() {
+        return unchokeInterval;
+    }
+
+    public int getOptimisticUnchokeInterval() {
+        return optimisticUnchokeInterval;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public int getFileSize() {
+        return fileSize;
+    }
+
+    public int getPieceSize() {
+        return pieceSize;
+    }
+
+    private final int numberPreferrredNeighbors;
+    private final int unchokeInterval;
+    private final int optimisticUnchokeInterval;
+
+    private final String fileName;
+    private final int fileSize;
+    private final int pieceSize;
+
+    private CommonConfigData(int numberPreferrredNeighbors, int unchokeInterval, int optimisticUnchokeInterval, String fileName, int fileSize, int pieceSize) {
+        this.numberPreferrredNeighbors = numberPreferrredNeighbors;
+        this.unchokeInterval = unchokeInterval;
+        this.optimisticUnchokeInterval = optimisticUnchokeInterval;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.pieceSize = pieceSize;
+    }
+
+    public static class CommonConfigDataBuilder {
+        int numberPreferrredNeighbors;
+        int unchokeInterval;
+        int optimisticUnchokeInterval;
+        String fileName;
+        int fileSize;
+        int pieceSize;
+
+        public void withFile(int fileSize, String name, int pieceSize) {
+            this.fileName = name;
+            this.pieceSize = pieceSize;
+            this.fileSize = fileSize;
+        }
+
+        public void withFileSize(int fileSize) {
+            this.fileSize = fileSize;
+        }
+        public void withFileName(String fileName) {
+            this.fileName = fileName;
+        }
+        public void withPieceSize(int pieceSize) {
+            this.pieceSize = pieceSize;
+        }
+
+        public void withUnchokeInterval(int unchokeInterval){
+            this.unchokeInterval = unchokeInterval;
+        }
+
+        public void withOptimisticUnchokeInterval(int optimisticUnchokeInterval) {
+            this.optimisticUnchokeInterval = optimisticUnchokeInterval;
+        }
+
+        public void withNumberPreferredNeighbors(int neighbors) {
+            this.numberPreferrredNeighbors = neighbors;
+        }
+
+        public CommonConfigData build()  {
+            return new CommonConfigData(numberPreferrredNeighbors, unchokeInterval, optimisticUnchokeInterval, fileName, fileSize, pieceSize);
+        }
+
+    }
+
+    public static CommonConfigDataBuilder getBuilder() {
+        return new CommonConfigDataBuilder();
+    }
+}

--- a/src/main/config/pod/PeerConfigData.java
+++ b/src/main/config/pod/PeerConfigData.java
@@ -1,4 +1,33 @@
 package main.config.pod;
 
 public class PeerConfigData {
+
+    public final int peerId;
+    public final String hostName;
+    public final int listeningPort;
+    public final boolean hasFileOrNot;
+
+    public PeerConfigData(int peerId, String hostName, int listeningPort, boolean hasFileOrNot) {
+        this.peerId = peerId;
+        this.hasFileOrNot = hasFileOrNot;
+        this.hostName = hostName;
+        this.listeningPort = listeningPort;
+    }
+
+    // Doesn't really make sense to have this except for testing
+    @Override
+    public boolean equals(Object obj) {
+        if ( obj == null ) {
+            return false;
+        }
+        if ( !PeerConfigData.class.isAssignableFrom(obj.getClass()))  {
+            return false;
+        }
+        PeerConfigData data = (PeerConfigData)obj;
+        return this.peerId == data.peerId && this.hostName.equals(data.hostName)
+                && this.listeningPort == data.listeningPort
+                && this.hasFileOrNot == data.hasFileOrNot;
+    }
+
+
 }

--- a/src/main/config/pod/PeerConfigData.java
+++ b/src/main/config/pod/PeerConfigData.java
@@ -1,0 +1,4 @@
+package main.config.pod;
+
+public class PeerConfigData {
+}

--- a/src/main/config/reader/CommonConfigReader.java
+++ b/src/main/config/reader/CommonConfigReader.java
@@ -1,0 +1,174 @@
+package main.config.reader;
+
+import main.config.pod.CommonConfigData;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+
+public class CommonConfigReader {
+    CommonConfigData data;
+    CommonConfigData getData() {
+        return data;
+    }
+
+    abstract class FillProperty {
+        public String myKeyword;
+        public FillProperty(String myKeyword) {
+            this.myKeyword = myKeyword;
+        }
+
+        boolean calledStore = false;
+        public void store(String keyword, Scanner sc) {
+            if ( calledStore ) {
+                throw new IllegalArgumentException("Error, same keyword found twice in the config file! Keyword was : " + keyword);
+            }
+            calledStore = true;
+            doCalledStore(sc);
+        }
+        protected abstract void doCalledStore(Scanner sc);
+        public void write(CommonConfigData.CommonConfigDataBuilder builder) {
+            if ( !calledStore ) {
+                throw new IllegalArgumentException("Error, a keyword that was expected to be in the config file, did not appear! Keyword expected but not found was: " + myKeyword);
+            }
+            doCalledWrite(builder);
+        }
+        protected abstract void doCalledWrite(CommonConfigData.CommonConfigDataBuilder builder);
+    }
+
+    Map<String, FillProperty> propertyMap = new HashMap<>();
+
+    CommonConfigReader(File f) {
+        populatePropertyMap();
+        try {
+            Scanner sc = new Scanner(f);
+            while(sc.hasNextLine()) {
+                Scanner lineScanner = new Scanner(sc.nextLine());
+                String keyword = lineScanner.next();
+                FillProperty fillProp = propertyMap.get(keyword);
+                if ( fillProp == null ) {
+                    throw new IllegalArgumentException("Error, unrecognized keyword found in common config file!");
+                }
+                fillProp.store(keyword, sc);
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        CommonConfigData.CommonConfigDataBuilder builder = CommonConfigData.getBuilder();
+        for (FillProperty fillProperty : propertyMap.values() ) {
+            fillProperty.write(builder);
+        }
+        data = builder.build();
+    }
+
+    private void populatePropertyMap() {
+       propertyMap.put("NumberOfPreferredNeighbors", new FillProperty("NumberOfPreferredNeighbors") {
+           int value = 0;
+           @Override
+           protected void doCalledStore(Scanner sc) {
+                if ( sc.hasNextInt()) {
+                    value = sc.nextInt();
+                } else {
+                    throw new IllegalArgumentException("Expected a integer after keyword NumberOfPreferredNeighbors!");
+                }
+           }
+
+           @Override
+           protected void doCalledWrite(CommonConfigData.CommonConfigDataBuilder builder) {
+                builder.withNumberPreferredNeighbors(value);
+           }
+       });
+
+        propertyMap.put("UnchokingInterval", new FillProperty("UnchokingInterval") {
+            int value = 0;
+            @Override
+            protected void doCalledStore(Scanner sc) {
+                if ( sc.hasNextInt()) {
+                    value = sc.nextInt();
+                } else {
+                    throw new IllegalArgumentException("Expected a integer after keyword UnchokingInterval");
+                }
+            }
+
+            @Override
+            protected void doCalledWrite(CommonConfigData.CommonConfigDataBuilder builder) {
+                builder.withUnchokeInterval(value);
+            }
+        });
+
+        propertyMap.put("OptimisticUnchokingInterval", new FillProperty("OptimisticUnchokingInterval") {
+            int value = 0;
+            @Override
+            protected void doCalledStore(Scanner sc) {
+                if ( sc.hasNextInt()) {
+                    value = sc.nextInt();
+                } else {
+                    throw new IllegalArgumentException("Expected a integer after keyword OptimisticUnchokingInterval");
+                }
+            }
+
+            @Override
+            protected void doCalledWrite(CommonConfigData.CommonConfigDataBuilder builder) {
+                builder.withOptimisticUnchokeInterval(value);
+            }
+        });
+
+
+        propertyMap.put("FileName", new FillProperty("FileName") {
+            String value;
+            @Override
+            protected void doCalledStore(Scanner sc) {
+                if ( sc.hasNext()) {
+                    value = sc.next();
+                } else {
+                    throw new IllegalArgumentException("Expected a name after keyword FileName");
+                }
+            }
+
+            @Override
+            protected void doCalledWrite(CommonConfigData.CommonConfigDataBuilder builder) {
+                builder.withFileName(value);
+            }
+        });
+
+
+        propertyMap.put("FileSize", new FillProperty("FileSize") {
+            int value = 0;
+            @Override
+            protected void doCalledStore(Scanner sc) {
+                if ( sc.hasNextInt()) {
+                    value = sc.nextInt();
+                } else {
+                    throw new IllegalArgumentException("Expected a integer after keyword FileSize");
+                }
+            }
+
+            @Override
+            protected void doCalledWrite(CommonConfigData.CommonConfigDataBuilder builder) {
+                builder.withFileSize(value);
+            }
+        });
+
+
+        propertyMap.put("PieceSize", new FillProperty("PieceSize") {
+            int value = 0;
+            @Override
+            protected void doCalledStore(Scanner sc) {
+                if ( sc.hasNextInt()) {
+                    value = sc.nextInt();
+                } else {
+                    throw new IllegalArgumentException("Expected a integer after keyword PieceSize");
+                }
+            }
+
+            @Override
+            protected void doCalledWrite(CommonConfigData.CommonConfigDataBuilder builder) {
+                builder.withPieceSize(value);
+            }
+        });
+
+    }
+}

--- a/src/main/config/reader/PeerConfigReader.java
+++ b/src/main/config/reader/PeerConfigReader.java
@@ -1,0 +1,19 @@
+package main.config.reader;
+
+import main.config.pod.PeerConfigData;
+
+import java.io.File;
+import java.util.ArrayList;
+
+public class PeerConfigReader {
+    ArrayList<PeerConfigData> data;
+    ArrayList<PeerConfigData> getPeerConfigDatas() {
+        return data;
+    }
+
+    PeerConfigReader(File configFile) {
+        // Perform the read and parse.
+
+    }
+
+}

--- a/src/main/config/reader/PeerConfigReader.java
+++ b/src/main/config/reader/PeerConfigReader.java
@@ -3,17 +3,77 @@ package main.config.reader;
 import main.config.pod.PeerConfigData;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
+import java.util.Scanner;
 
 public class PeerConfigReader {
-    ArrayList<PeerConfigData> data;
+    ArrayList<PeerConfigData> data = new ArrayList<>();
     ArrayList<PeerConfigData> getPeerConfigDatas() {
         return data;
     }
 
-    PeerConfigReader(File configFile) {
-        // Perform the read and parse.
+    private String getFieldExceptionMessage(int lineIdx, String fieldMissing, String line, String error) {
+        return "On line:" + lineIdx + ", Field:" + fieldMissing + ", is " + error + ". \n \t Line is:" + line;
+    }
 
+    private PeerConfigData getPeerConfigDataFromLine(String line, int currentLineIdx) {
+        Scanner lineScanner = new Scanner(line);
+        int peerId = 0;
+        if (lineScanner.hasNextInt()) {
+            peerId = lineScanner.nextInt();
+            if (peerId < 0) {
+                throw new IllegalArgumentException(getFieldExceptionMessage(currentLineIdx, "PeerId", line, "a negative value"));
+            }
+        } else {
+                throw new IllegalArgumentException(getFieldExceptionMessage(currentLineIdx, "PeerId", line, "missing"));
+        }
+
+        String hostName = "";
+        if (lineScanner.hasNext()) {
+            hostName = lineScanner.next();
+        } else {
+            throw new IllegalArgumentException(getFieldExceptionMessage(currentLineIdx,"HostName",line, "missing"));
+        }
+
+        int listeningPort = 0;
+        if (lineScanner.hasNextInt()) {
+            listeningPort = lineScanner.nextInt();
+            if (listeningPort < 0) {
+                throw new IllegalArgumentException(getFieldExceptionMessage(currentLineIdx, "Listening Port", line, "a negative value"));
+            }
+        } else {
+            throw new IllegalArgumentException(getFieldExceptionMessage(currentLineIdx,"ListeningPort",line, "missing"));
+        }
+
+        boolean hasFile = false;
+        if (lineScanner.hasNextInt()) {
+            int hasFileRawInt = lineScanner.nextInt();
+            if (hasFileRawInt < 0) {
+                throw new IllegalArgumentException(getFieldExceptionMessage(currentLineIdx, "hasFile", line, "a negative value"));
+            }
+            hasFile = (hasFileRawInt != 0);
+
+        } else {
+            throw new IllegalArgumentException(getFieldExceptionMessage(currentLineIdx,"hasFile",line, "missing"));
+        }
+
+        if ( lineScanner.hasNext() ) {
+            throw new IllegalArgumentException(getFieldExceptionMessage(currentLineIdx,"N/A",line,"extra data on this line"));
+        }
+
+        return new PeerConfigData(peerId,hostName,listeningPort,hasFile);
+
+    }
+
+    // Throws either FileNotFound if the file doesn't exist, or IllegalArgumentException if the file is formatted incorrectly.
+    PeerConfigReader(File configFile) throws FileNotFoundException, IllegalArgumentException {
+        // Perform the read and parse.
+        Scanner sc = new Scanner(configFile);
+        for(int currentLineIdx = 0; sc.hasNext();++currentLineIdx) {
+            data.add(getPeerConfigDataFromLine(sc.nextLine(),currentLineIdx));
+
+        }
     }
 
 }

--- a/tests/main/config/pod/CommonConfigDataTest.java
+++ b/tests/main/config/pod/CommonConfigDataTest.java
@@ -1,0 +1,41 @@
+package main.config.pod;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CommonConfigDataTest {
+    @Test
+    public void testBuilder() {
+        CommonConfigData.CommonConfigDataBuilder builder = new CommonConfigData.CommonConfigDataBuilder();
+        int numNeighbors = 5;
+        int numUnchoke = 6;
+        int numOptiUnchoke = 7;
+
+        int fileSize = 8;
+        int pieceSize = 9;
+        String fileName = "";
+
+        builder.withFileName(fileName);
+        builder.withFileSize(fileSize);
+        builder.withPieceSize(pieceSize);
+
+        builder.withNumberPreferredNeighbors(numNeighbors);
+        builder.withOptimisticUnchokeInterval(numOptiUnchoke);
+        builder.withUnchokeInterval(numUnchoke);
+
+        CommonConfigData data = builder.build();
+
+        Assert.assertEquals(data.getFileName(),fileName);
+        Assert.assertEquals(data.getFileSize(),fileSize);
+        Assert.assertEquals(data.getPieceSize(),pieceSize);
+
+        Assert.assertEquals(data.getNumberPreferrredNeighbors(),numNeighbors);
+        Assert.assertEquals(data.getUnchokeInterval(),numUnchoke);
+        Assert.assertEquals(data.getOptimisticUnchokeInterval(), numOptiUnchoke);
+
+
+    }
+
+}

--- a/tests/main/config/reader/CommonConfigReaderTest.java
+++ b/tests/main/config/reader/CommonConfigReaderTest.java
@@ -1,0 +1,115 @@
+package main.config.reader;
+
+import main.config.pod.CommonConfigData;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.*;
+
+import static org.junit.Assert.*;
+public class CommonConfigReaderTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+
+    File createTestFile(String contents) {
+        try {
+            File testFile = temporaryFolder.newFile();
+            FileOutputStream writer = new FileOutputStream(testFile);
+            writer.write(contents.getBytes());
+            writer.close();
+            return testFile;
+        } catch(IOException ioexcept) {
+            Assert.assertTrue(false);
+        }
+        return null;
+    }
+
+    @Test
+    public void FullyPopulatedConfigFile() throws FileNotFoundException {
+        File f = createTestFile("NumberOfPreferredNeighbors 2 \n" +
+                "UnchokingInterval 5 \n" +
+                "OptimisticUnchokingInterval 15 \n" +
+                "FileName TheFile.dat \n" +
+                "FileSize 10000323 \n " +
+                "PieceSize 32768");
+        CommonConfigReader reader = new CommonConfigReader(f);
+        CommonConfigData data = reader.getData();
+        Assert.assertEquals(data.getFileName(),"TheFile.dat");
+        Assert.assertEquals(data.getFileSize(),10000323);
+        Assert.assertEquals(data.getPieceSize(),32768);
+        Assert.assertEquals(data.getOptimisticUnchokeInterval(),15);
+        Assert.assertEquals(data.getUnchokeInterval(),5);
+        Assert.assertEquals(data.getNumberPreferrredNeighbors(),2);
+    }
+
+    @Test
+    public void DuplicatedFieldInConfigFile() {
+        File f = createTestFile("NumberOfPreferredNeighbors 2 \n" +
+                "UnchokingInterval 5 \n" +
+                "UnchokingInterval 5 \n" +
+                "OptimisticUnchokingInterval 15 \n" +
+                "FileName TheFile.dat \n" +
+                "FileSize 10000323 \n " +
+                "PieceSize 32768");
+        boolean found = false;
+        try {
+            CommonConfigReader reader = new CommonConfigReader(f);
+        } catch(Exception e) {
+            if ( e.toString().contains("twice") && e.toString().contains("UnchokingInterval") && e.toString().contains("line:2")) {
+                found = true;
+            }
+            else {
+                System.out.println(e);
+            }
+        }
+        Assert.assertTrue(found);
+    }
+
+    @Test
+    public void MissingFieldInConfigFile() {
+        File f = createTestFile("NumberOfPreferredNeighbors 2 \n" +
+                "OptimisticUnchokingInterval 15 \n" +
+                "FileName TheFile.dat \n" +
+                "FileSize 10000323 \n " +
+                "PieceSize 32768");
+        boolean found = false;
+        try {
+            CommonConfigReader reader = new CommonConfigReader(f);
+        } catch(Exception e) {
+            if ( e.toString().contains("expected") && e.toString().contains("UnchokingInterval")) {
+                found = true;
+            }
+            else {
+                System.out.println(e);
+            }
+        }
+        Assert.assertTrue(found);
+    }
+
+
+    @Test
+    public void MissingValueForFieldInConfigFile() {
+        File f = createTestFile("NumberOfPreferredNeighbors 2 \n" +
+                "UnchokingInterval \n" +
+                "OptimisticUnchokingInterval 15\n" +
+                "FileName TheFile.dat \n" +
+                "FileSize 10000323 \n " +
+                "PieceSize 32768");
+        boolean found = false;
+        try {
+            CommonConfigReader reader = new CommonConfigReader(f);
+        } catch(Exception e) {
+            if ( e.toString().contains("integer") && e.toString().contains("UnchokingInterval") && e.toString().contains("line:1")) {
+                found = true;
+            }
+            else {
+                System.out.println(e);
+            }
+        }
+        Assert.assertTrue(found);
+    }
+
+}

--- a/tests/main/config/reader/PeerConfigReaderTest.java
+++ b/tests/main/config/reader/PeerConfigReaderTest.java
@@ -1,0 +1,105 @@
+package main.config.reader;
+
+import main.config.pod.PeerConfigData;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+public class PeerConfigReaderTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+
+    File createTestFile(String contents) {
+        try {
+            File testFile = temporaryFolder.newFile();
+            FileOutputStream writer = new FileOutputStream(testFile);
+            writer.write(contents.getBytes());
+            writer.close();
+            return testFile;
+        } catch(IOException ioexcept) {
+            Assert.assertTrue(false);
+        }
+        return null;
+    }
+
+    public void assertPeerConfigDataEqual(PeerConfigData expected, PeerConfigData actual) {
+        Assert.assertEquals(expected,actual);
+    }
+
+    public void assertUnorderedPeerArraysEqual(ArrayList<PeerConfigData> expected, ArrayList<PeerConfigData> actual) {
+        Assert.assertTrue(actual.containsAll(expected) && expected.containsAll(actual));
+    }
+
+
+    @Test
+    public void ZeroPeersInFile() throws FileNotFoundException{
+        File testFile = createTestFile("");
+        PeerConfigReader reader = new PeerConfigReader(testFile);
+        Assert.assertEquals(0,reader.getPeerConfigDatas().size());
+    }
+
+    @Test
+    public void onePeerInFile() throws FileNotFoundException{
+        File testFile = createTestFile("1001 lin114-00.cise.ufl.edu 6008 1");
+        PeerConfigReader reader = new PeerConfigReader(testFile);
+        Assert.assertEquals(1,reader.getPeerConfigDatas().size());
+        PeerConfigData expectedData = new PeerConfigData(1001, "lin114-00.cise.ufl.edu", 6008, true);
+        assertPeerConfigDataEqual(expectedData,reader.getPeerConfigDatas().get(0));
+    }
+
+    @Test
+    public void TwoPeersInFile() throws FileNotFoundException{
+        File testFile = createTestFile("1001 lin114-00.cise.ufl.edu 6008 1 \n 1002 lin115-00.cise.ufl.edu 6009 0");
+        PeerConfigReader reader = new PeerConfigReader(testFile);
+        Assert.assertEquals(2,reader.getPeerConfigDatas().size());
+        ArrayList<PeerConfigData> expectedPeerConfigs = new ArrayList<>();
+        expectedPeerConfigs.add(new PeerConfigData(1001, "lin114-00.cise.ufl.edu", 6008, true));
+        expectedPeerConfigs.add(new PeerConfigData(1002, "lin115-00.cise.ufl.edu", 6009, false));
+        assertUnorderedPeerArraysEqual(expectedPeerConfigs,reader.getPeerConfigDatas());
+    }
+
+
+    @Test
+    public void MissingAField() throws FileNotFoundException{
+        File testFile = createTestFile("lin114-00.cise.ufl.edu 6008 1");
+        boolean found = false;
+        try {
+            PeerConfigReader reader = new PeerConfigReader(testFile);
+        } catch(IllegalArgumentException e) {
+            if ( e.toString().contains("Field:PeerId") && e.toString().contains("line:0")) {
+                found = true;
+            } else {
+                System.out.println(e.toString());
+            }
+        }
+        Assert.assertTrue(found);
+    }
+
+    @Test
+    public void ExtraField() throws FileNotFoundException{
+        File testFile = createTestFile("1001 lin114-00.cise.ufl.edu 6008 1 100");
+        boolean found = false;
+        try {
+            PeerConfigReader reader = new PeerConfigReader(testFile);
+        } catch(IllegalArgumentException e) {
+            if ( e.toString().contains("Field:N/A") && e.toString().contains("line:0") && e.toString().contains("extra data")) {
+                found = true;
+            } else {
+                System.out.println(e.toString());
+            }
+        }
+        Assert.assertTrue(found);
+    }
+
+}


### PR DESCRIPTION
Adds config file readers.
Both readers check the data for correctness to a reasonable amount.
By reasonable amount, I mean
No fields missing, no extra fields, and all fields are the correct type.
They will not ignore extraneous lines of garbage.
Error will include the line number, and line contents if applicable. 
